### PR TITLE
Replace apricot with submodlib

### DIFF
--- a/cords/selectionstrategies/SL/craigstrategy.py
+++ b/cords/selectionstrategies/SL/craigstrategy.py
@@ -1,5 +1,5 @@
 import math
-import apricot
+from submodlib.functions.facilityLocation import FacilityLocationFunction
 import numpy as np
 import time
 import torch
@@ -59,12 +59,14 @@ class CRAIGStrategy(DataSelectionStrategy):
     logger : class
         - logger object for logging the information
     optimizer: str
-        Type of Greedy Algorithm
+        The optimizer used to compute the optimal subset. Can be 'NaiveGreedy', 'StochasticGreedy', 'LazyGreedy', or 'LazierThanLazyGreedy'.
+    num_neighbors: int, default=5
+        Number of neighbors applicable for the sparse similarity kernel.
     """
 
     def __init__(self, trainloader, valloader, model, loss,
                  device, num_classes, linear_layer, if_convex,
-                 selection_type, logger, optimizer='lazy'):
+                 selection_type, logger, optimizer='NaiveGreedy', num_neighbors=5):
         """
         Constructer method
         """
@@ -73,6 +75,7 @@ class CRAIGStrategy(DataSelectionStrategy):
         self.selection_type = selection_type
         self.logger = logger
         self.optimizer = optimizer
+        self.num_neighbors = num_neighbors
 
     def distance(self, x, y, exp=2):
         """
@@ -259,13 +262,11 @@ class CRAIGStrategy(DataSelectionStrategy):
         if self.selection_type == 'PerClass':
             for i in range(self.num_classes):
                 idxs = torch.where(labels == i)[0]
+                N = len(idxs)
                 self.compute_score(model_params, idxs)
-                fl = apricot.functions.facilityLocation.FacilityLocationSelection(random_state=0, metric='precomputed',
-                                                                                  n_samples=math.ceil(
-                                                                                      budget * len(idxs) / self.N_trn),
-                                                                                  optimizer=self.optimizer)
-                sim_sub = fl.fit_transform(self.dist_mat)
-                greedyList = list(np.argmax(sim_sub, axis=1))
+                n_samples = math.ceil(budget * len(idxs) / self.N_trn)
+                fl = FacilityLocationFunction(n=N, mode='dense', separate_rep=False, sijs=self.dist_mat)
+                greedyList = [idx for idx, _ in fl.maximize(n_samples, optimizer=self.optimizer)]
                 gamma = self.compute_gamma(greedyList)
                 total_greedy_list.extend(idxs[greedyList])
                 gammas.extend(gamma)
@@ -281,22 +282,16 @@ class CRAIGStrategy(DataSelectionStrategy):
             data = self.dist_mat.flatten()
             sparse_simmat = csr_matrix((data, (row.numpy(), col.numpy())), shape=(self.N_trn, self.N_trn))
             self.dist_mat = sparse_simmat
-            fl = apricot.functions.facilityLocation.FacilityLocationSelection(random_state=0, metric='precomputed',
-                                                                              n_samples=budget,
-                                                                              optimizer=self.optimizer)
-            sim_sub = fl.fit_transform(sparse_simmat)
-            total_greedy_list = list(np.array(np.argmax(sim_sub, axis=1)).reshape(-1))
+            n_samples=budget
+            fl = FacilityLocationFunction(n=N, mode='sparse', sijs=sparse_simmat, num_neighbors=self.num_neighbors)
+            total_greedy_list = [idx for idx, _ in fl.maximize(n_samples, optimizer=self.optimizer)]
             gammas = self.compute_gamma(total_greedy_list)
         elif self.selection_type == 'PerBatch':
             idxs = torch.arange(self.N_trn)
-            N = len(idxs)
             self.compute_score(model_params, idxs)
-            fl = apricot.functions.facilityLocation.FacilityLocationSelection(random_state=0, metric='precomputed',
-                                                                              n_samples=math.ceil(
-                                                                                  budget / self.trainloader.batch_size),
-                                                                              optimizer=self.optimizer)
-            sim_sub = fl.fit_transform(self.dist_mat)
-            temp_list = list(np.array(np.argmax(sim_sub, axis=1)).reshape(-1))
+            n_samples = math.ceil(budget / self.trainloader.batch_size)
+            fl = FacilityLocationFunction(n=self.dist_mat.shape[0], mode='dense', separate_rep=False, sijs=self.dist_mat)
+            temp_list = [idx for idx, _ in fl.maximize(n_samples, optimizer=self.optimizer)]
             gammas_temp = self.compute_gamma(temp_list)
             batch_wise_indices = list(self.trainloader.batch_sampler)
             for i in range(len(temp_list)):

--- a/cords/utils/data/dataloader/SL/nonadaptive/__init__.py
+++ b/cords/utils/data/dataloader/SL/nonadaptive/__init__.py
@@ -3,4 +3,4 @@ from .nonadaptivedataloader import NonAdaptiveDSSDataLoader
 from .submoddataloader import FacLocDataLoader
 from .submoddataloader import GraphCutDataLoader
 from .submoddataloader import SaturatedCoverageDataLoader
-from .submoddataloader import SumRedundancyDataLoader
+#from .submoddataloader import SumRedundancyDataLoader

--- a/cords/utils/data/dataloader/SL/nonadaptive/submoddataloader.py
+++ b/cords/utils/data/dataloader/SL/nonadaptive/submoddataloader.py
@@ -1,5 +1,5 @@
 import numpy as np
-import apricot
+import submodlib
 import math
 from .nonadaptivedataloader import NonAdaptiveDSSDataLoader
 import torch
@@ -119,9 +119,8 @@ class FacLocDataLoader(SubmodDataLoader):
         ranking: list
             Ranking of the samples based on the facility location gain 
         """
-        f = apricot.functions.facilityLocation.FacilityLocationSelection(n_samples=n_samples)
-        m = f.fit(chunk)
-        return list(m.ranking)
+        fl = submodlib.functions.facilityLocation.FacilityLocationFunction(n=len(chunk), mode='dense', data=chunk)
+        return [idx for idx, _ in fl.maximize(n_samples)]
 
 
 class GraphCutDataLoader(SubmodDataLoader):
@@ -162,11 +161,10 @@ class GraphCutDataLoader(SubmodDataLoader):
         ranking: list
             Ranking of the samples based on the graphcut gain 
         """
-        f = apricot.functions.graphCut.GraphCutSelection(n_samples=n_samples)
-        m = f.fit(chunk)
-        return list(m.ranking)
+        fl = submodlib.functions.graphCut.graphCutFunction(n=len(chunk), mode='dense', data=chunk)
+        return [idx for idx, _ in fl.maximize(n_samples)]
 
-
+'''
 class SumRedundancyDataLoader(SubmodDataLoader):
     """
     Implementation of SumRedundancyDataLoader class for the nonadaptive sum redundancy function
@@ -207,7 +205,7 @@ class SumRedundancyDataLoader(SubmodDataLoader):
         f = apricot.functions.sumRedundancy.SumRedundancySelection(n_samples=n_samples)
         m = f.fit(chunk)
         return list(m.ranking)
-
+'''
 
 class SaturatedCoverageDataLoader(SubmodDataLoader):
     """
@@ -246,6 +244,5 @@ class SaturatedCoverageDataLoader(SubmodDataLoader):
         ranking: list
             Ranking of the samples based on the saturated coverage gain 
         """
-        f = apricot.functions.facilityLocation.FacilityLocationSelection(n_samples=n_samples)
-        m = f.fit(chunk)
-        return list(m.ranking)
+        fl = submodlib.functions.saturatedCoverage.saturatedCoverageFunction(n=len(chunk), mode='dense', data=chunk)
+        return [idx for idx, _ in fl.maximize(n_samples)]

--- a/cords/utils/data/dataloader/SSL/nonadaptive/__init__.py
+++ b/cords/utils/data/dataloader/SSL/nonadaptive/__init__.py
@@ -3,4 +3,4 @@ from .nonadaptivedataloader import NonAdaptiveDSSDataLoader
 from .submoddataloader import FacLocDataLoader
 from .submoddataloader import GraphCutDataLoader
 from .submoddataloader import SaturatedCoverageDataLoader
-from .submoddataloader import SumRedundancyDataLoader
+#from .submoddataloader import SumRedundancyDataLoader

--- a/cords/utils/data/dataloader/SSL/nonadaptive/submoddataloader.py
+++ b/cords/utils/data/dataloader/SSL/nonadaptive/submoddataloader.py
@@ -1,5 +1,5 @@
 import numpy as np
-import apricot
+import submodlib
 import math
 from .nonadaptivedataloader import NonAdaptiveDSSDataLoader
 
@@ -91,9 +91,8 @@ class FacLocDataLoader(SubmodDataLoader):
         ranking: list
             Ranking of the samples based on the facility location gain 
         """
-        f = apricot.functions.facilityLocation.FacilityLocationSelection(n_samples=n_samples)
-        m = f.fit(chunk)
-        return list(m.ranking)
+        fl = submodlib.functions.facilityLocation.FacilityLocationFunction(n=len(chunk), mode='dense', data=chunk)
+        return [idx for idx, _ in fl.maximize(n_samples)]
 
 
 class GraphCutDataLoader(SubmodDataLoader):
@@ -128,11 +127,10 @@ class GraphCutDataLoader(SubmodDataLoader):
         ranking: list
             Ranking of the samples based on the graphcut gain 
         """
-        f = apricot.functions.graphCut.GraphCutSelection(n_samples=n_samples)
-        m = f.fit(chunk)
-        return list(m.ranking)
+        fl = submodlib.functions.graphCut.graphCutFunction(n=len(chunk), mode='dense', data=chunk)
+        return [idx for idx, _ in fl.maximize(n_samples)]
 
-
+'''
 class SumRedundancyDataLoader(SubmodDataLoader):
     """
     Implementation of SumRedundancyDataLoader class for the nonadaptive sum redundancy function
@@ -167,7 +165,7 @@ class SumRedundancyDataLoader(SubmodDataLoader):
         f = apricot.functions.sumRedundancy.SumRedundancySelection(n_samples=n_samples)
         m = f.fit(chunk)
         return list(m.ranking)
-
+'''
 
 class SaturatedCoverageDataLoader(SubmodDataLoader):
     """
@@ -200,6 +198,5 @@ class SaturatedCoverageDataLoader(SubmodDataLoader):
         ranking: list
             Ranking of the samples based on the saturated coverage gain 
         """
-        f = apricot.functions.facilityLocation.FacilityLocationSelection(n_samples=n_samples)
-        m = f.fit(chunk)
-        return list(m.ranking)
+        fl = submodlib.functions.saturatedCoverage.saturatedCoverageFunction(n=len(chunk), mode='dense', data=chunk)
+        return [idx for idx, _ in fl.maximize(n_samples)]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,3 @@
-apricot-select>=0.6.0
 numba>=0.43.0
 scipy>=1.5.0
 scikit-learn
@@ -21,3 +20,4 @@ setuptools~=58.0.4
 ray[tune]
 ray[default]
 datasets
+submodlib

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     packages=setuptools.find_packages(),
     description='cords is a package for data subset selection for efficient and robust machine learning.',
     install_requires=[
-        "apricot-select>=0.6.0",
         "numba>=0.43.0",
         "scipy>=1.5.0",
         "scikit-learn",
@@ -34,6 +33,7 @@ setup(
         "setuptools>=58.0.4",
         "ray[tune]",
         "ray[default]",
-        "datasets"
+        "datasets",
+        "submodlib"
             ],
 )


### PR DESCRIPTION
Fixes #16  
submodlib is now used for the CRAIG strategy/dataloader as well as the submodular strategy/dataloader.  Please let me know if you have any feedback!

Notes:
- I am not sure if sum redundancy (a submodular function implemented in apricot) has an analogue in submodlib, so it is disabled as an option for now.
- It doesn't seem like submodularselectionstrategy.py is used in the corresponding dataloader.  This may be a good opportunity to refactor, so that behavior is consistent between the two.
- Any existing code that specifies the "optimizer" (greedy algorithm) used by apricot will break, since the names used by submodlib are different than those used by apricot (e.g. 'LazyGreedy' instead of 'Lazy'). This includes configs that use this option.